### PR TITLE
Setup database migrations, initialize db and implement models

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ FROM alpine:latest
 WORKDIR /www
 COPY --from=build-frontend /client/static client/static
 COPY --from=build-backend /go/src/github.com/HackGT/SponsorshipPortal .
-CMD ./SponsorshipPortal
+CMD ./SponsorshipPortal --migrate && ./SponsorshipPortal

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -44,6 +44,18 @@
   revision = "88edab0803230a3898347e77b474f8c1820a1f20"
 
 [[projects]]
+  name = "github.com/mattes/migrate"
+  packages = [
+    ".",
+    "database",
+    "database/postgres",
+    "source",
+    "source/file"
+  ]
+  revision = "035c07716cd373d88456ec4d701402df52584cb4"
+  version = "v3.0.1"
+
+[[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "d682213848ed68c0a260ca37d6dd5ace8423f5ba"
@@ -67,6 +79,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2e0919b35ce4915610ad998897a817c977568b02bcd4d03710b97f9de12d56f5"
+  inputs-digest = "47daa5674ac8011585370b5343199c50178072778c79ea87b868a182046b8767"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,3 +1,7 @@
+[prune]
+  go-tests = true
+  unused-packages = true
+
 [[constraint]]
   name = "github.com/gorilla/mux"
   version = "1.6"
@@ -22,6 +26,6 @@
   name = "github.com/lib/pq"
   branch = "master"
 
-[prune]
-  go-tests = true
-  unused-packages = true
+[[constraint]]
+  name = "github.com/mattes/migrate"
+  version = "3.0.0"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Make sure you have a `GOHOME` directory set up
 2. [dep](https://golang.github.io/dep/) - Dependency manager for go - install with `go get -u github.com/golang/dep/cmd/dep` after go is working
 3. [Node.js version 8.9.4](https://nodejs.org/en/) [[download](https://nodejs.org/en/download/)] - Used to build and run the frontend in development
 4. [yarn](https://yarnpkg.com/) [[install](https://yarnpkg.com/en/docs/install)] - Dependency manager for Node.js (use `npm` at your own risk!)
+5. [Postgres](http://postgresql.org/) - Relational database used as our primary datastore
 
 _Optional_: If you are working on the backend, install
 [gin](https://github.com/codegangsta/gin) (`go get github.com/codegangsta/gin`) for live-reloading capabilities.
@@ -26,7 +27,7 @@ To follow along, setup [homebrew](https://brew.sh) if you have not already.
 We will be installing all the tools in the previous section with `brew` or
 another package/version manager whenever possible.
 
-```
+```bash
 # Install go with homebrew
 brew install go
 # You might need to setup certain environment variables for go to work.
@@ -50,6 +51,11 @@ n 8.9.4
 
 # Install yarn with homebrew
 brew install yarn --without-node
+
+# Install Postgres with homebrew
+brew install postgres
+# Start Postgres
+brew services start postgresql
 ```
 
 [`n`](https://github.com/tj/n) is a version manager for Node.js and makes it very easy to switch versions painlessly.
@@ -59,10 +65,10 @@ You can confirm with `node --version`.
 
 **Note**: `go env` is very helpful in debugging go environment variables.
 
-## Installing
+## Installing and Setup
 
 Get the source code:
-```
+```bash
 go get github.com/HackGT/SponsorshipPortal
 ```
 You may get an error `no buildable Go source files`; this is harmless.
@@ -74,34 +80,95 @@ For development work run the frontend and backend separately.
 Before running the frontend for development change the file `frontend/src/js/configs.js` to assign the HOST to `export const HOST = window.location.protocol + '//' + 'localhost:9000';` This needs to be done or server-side communication won't work. (TODO: host should change automatically from environment variable)
 
 Install frontend dependencies:
-```
+```bash
 # from project root
 cd client
 yarn
 ```
 
 Install backend dependencies:
-```
+```bash
 # from project root
 dep ensure
 ```
 
+### Setup
+
+Make sure that PG_URL contains the connection string SponsorshipPortal will use
+to connect to Postgres.
+
+**NOTE:** `sslmode` defaults to `require` which may cause issues if you do not
+have SSL configured. This may not be an issue on `localhost`.
+
+Examples:
+```bash
+# connect as default user (`postgres`) to default database
+export PG_URL="postgres://postgres@localhost:5432/"
+
+# connect as `portal` user with password `secret`
+# to `dev` database with ssl disabled
+export PG_URL="postgres://portal:secret@localhost:5432/dev?sslmode=disable"
+
+# same connection as above in an alternate form
+# (this will work but not be parsed correctly by `config/config.go`)
+export PG_URL="host=localhost port=5432 user=portal password=secret sslmode=disable"
+```
+
+More information and examples on [Postgres docs](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING)
+
 ## Start the app!
 
-Start the backend
+Run the database migrations (see `migrations/README.md` for more info)
+```bash
+go run main.go --migrate
+# or if you do not want to set PG_URL for the current session
+PG_URL="<connection string>" go run main.go --migrate
 ```
+
+Start the backend
+```bash
 # from project root
 go run main.go
 # if you are working on the backend and have gin installed
 # (go get github.com/codegangsta/gin)
 gin run main.go
+
+# or set PG_URL for the command and run
+PG_URL="<connection string>" go run main.go
+# also works with `gin`
+PG_URL="<connection string>" gin run main.go
 ```
 
 Then, in a new shell, start the frontend and navigate to `localhost:8500`.
-```
+```bash
 # from project root
 cd frontend
 npm start
+```
+
+### Building and running
+
+#### Build the front-end
+
+```bash
+# build frontend
+# from project root...
+cd frontend
+npm run build
+```
+
+#### Build and run the server
+
+```bash
+# build backend
+# from project root...
+go build .
+
+# set connection string
+# run migrations and start server
+export PG_URL="<connection string>"
+./SponsorshipPortal --migrate
+./SponsorshipPortal
 ```
 
 ## Contributing
@@ -112,9 +179,14 @@ The application is written in go and heavily utilizes the standard library
 (`net/http` and `database/sql`) as well as packages from the [gorilla web toolkit](http://www.gorillatoolkit.org)
 ([`mux`](http://www.gorillatoolkit.org/pkg/mux)).
 
+If you are working only on the backend or the frontend, you can build (and start)
+the other part and leave it running while you do your development.
+Example: build the frontend and then build and run the backend with `gin`'s live
+reloads. See above [instructions](#building-and-running) on how to build each part.
+
 ### Code Layout
 
-The directory structure of a Revel application:
+The directory structure:
 ```
 main.go           Boot script for the server
 routes.go         Register non-controller routes go here
@@ -126,12 +198,14 @@ config/           App server config package
 
 controllers/      App controllers go here
     controller.go Root controller, register other controllers here
-    
+
 database/         Utility package for initializing a database connection from config
-    
+
 logger/           Utility package for initializing a logger from loaded config
 
 models/           App models go here
+
+migrations/       Database migrations (sql scripts) go here
 
 client/           Front-end project root
     package.json

--- a/config/config.go
+++ b/config/config.go
@@ -55,20 +55,20 @@ func (config *ServerConfig) Addr() string {
 }
 
 type DatabaseConfig struct {
-	Host             string `default="localhost:5432"`
-	DbName           string `default="portal"`
-	User             string
-	Password         string
-	ConnectionString string
+	Host     string `default="localhost:5432"`
+	DbName   string `default="portal"`
+	User     string
+	Password string
+	URL      string
 }
 
 func LoadDatabaseConfig() (*DatabaseConfig, error) {
 	var config DatabaseConfig
-	if err := envconfig.Process("DB", &config); err != nil {
+	if err := envconfig.Process("PG", &config); err != nil {
 		return nil, err
 	}
 
-	if config.ConnectionString == "" {
+	if config.URL == "" {
 
 		var userinfo *nurl.Userinfo
 		if config.User != "" {
@@ -84,9 +84,9 @@ func LoadDatabaseConfig() (*DatabaseConfig, error) {
 			User:   userinfo,
 			Path:   config.DbName,
 		}
-		config.ConnectionString = dbUrl.String()
+		config.URL = dbUrl.String()
 	} else {
-		dbUrl, err := nurl.Parse(config.ConnectionString)
+		dbUrl, err := nurl.Parse(config.URL)
 		if err != nil {
 			// TODO parse the "<key>=<value>[ <key>=<value>...]" format
 		} else {

--- a/config/config.go
+++ b/config/config.go
@@ -64,7 +64,7 @@ type DatabaseConfig struct {
 
 func LoadDatabaseConfig() (*DatabaseConfig, error) {
 	var config DatabaseConfig
-	if err := envconfig.Process("", &config); err != nil {
+	if err := envconfig.Process("DB", &config); err != nil {
 		return nil, err
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,9 @@ func LoadDatabaseConfig() (*DatabaseConfig, error) {
 				config.User = dbUrl.User.Username()
 				config.Password, _ = dbUrl.User.Password()
 			}
+			if len(dbUrl.Path) > 1 {
+				config.DbName = dbUrl.Path[1:]
+			}
 		}
 	}
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -2,12 +2,27 @@ package controller
 
 import (
 	"github.com/gorilla/mux"
+	"github.com/jmoiron/sqlx"
 
+	"github.com/HackGT/SponsorshipPortal/config"
+	"github.com/HackGT/SponsorshipPortal/controller/health"
 	"github.com/HackGT/SponsorshipPortal/controller/sample"
 )
 
-func Load(r *mux.Router) {
+type Controller struct {
+	DB     *sqlx.DB
+	Config *config.Config
+}
 
+func New(db *sqlx.DB, config *config.Config) *Controller {
+	return &Controller{
+		DB:     db,
+		Config: config,
+	}
+}
+
+func (c *Controller) Load(r *mux.Router) {
 	// Register controllers and their respective path prefixes
+	health.Load(r.PathPrefix("/_health").Subrouter(), c.DB.DB, c.Config.Database)
 	sample.Load(r.PathPrefix("/sample").Subrouter())
 }

--- a/controller/health/health.go
+++ b/controller/health/health.go
@@ -1,0 +1,41 @@
+package health
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/HackGT/SponsorshipPortal/config"
+	"github.com/HackGT/SponsorshipPortal/database"
+)
+
+type healthController struct {
+	db     *sql.DB
+	config *config.DatabaseConfig
+}
+
+func (h *healthController) Health(w http.ResponseWriter, r *http.Request) {
+	ready, err := database.IsReadyWithInstance(h.db, h.config)
+	var status int
+	var msg string
+	if err != nil {
+		status = http.StatusInternalServerError
+		msg = "Internal error"
+		log.WithError(err).Warn("Error retrieving health (migration state)")
+	} else if ready {
+		status = http.StatusOK
+		msg = "OK"
+	} else {
+		status = http.StatusServiceUnavailable
+		msg = "Unhealthy"
+	}
+	w.WriteHeader(status)
+	w.Write([]byte(msg))
+}
+
+func Load(r *mux.Router, db *sql.DB, config *config.DatabaseConfig) {
+	h := &healthController{db, config}
+	r.Methods("HEAD", "GET").HandlerFunc(h.Health)
+}

--- a/database/database.go
+++ b/database/database.go
@@ -8,7 +8,7 @@ import (
 )
 
 func New(config *config.DatabaseConfig) (*sqlx.DB, error) {
-	db, err := sqlx.Connect("postgres", config.ConnectionString)
+	db, err := sqlx.Connect("postgres", config.URL)
 	if err != nil {
 		return nil, err
 	}

--- a/database/migration.go
+++ b/database/migration.go
@@ -1,12 +1,35 @@
 package database
 
 import (
+	"database/sql"
+
 	"github.com/mattes/migrate"
-	_ "github.com/mattes/migrate/database/postgres"
+	"github.com/mattes/migrate/database/postgres"
 	_ "github.com/mattes/migrate/source/file"
+
+	"github.com/HackGT/SponsorshipPortal/config"
 )
 
 const MigrationSource string = "file://migrations"
+
+func loadFromConfig(db *sql.DB, config *config.DatabaseConfig) (*migrate.Migrate, error) {
+	pgDriver, err := postgres.WithInstance(db, &postgres.Config{
+		MigrationsTable: postgres.DefaultMigrationsTable,
+		DatabaseName:    config.DbName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m, err := migrate.NewWithDatabaseInstance(
+		MigrationSource,
+		"postgres", pgDriver,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
 
 func Migrate(connString string) error {
 	m, err := migrate.New(
@@ -24,4 +47,25 @@ func Migrate(connString string) error {
 
 	_, err = m.Close()
 	return err
+}
+
+func IsReadyWithInstance(db *sql.DB, config *config.DatabaseConfig) (bool, error) {
+	m, err := loadFromConfig(db, config)
+	if err != nil {
+		if err == postgres.ErrDatabaseDirty {
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+
+	_, dirty, err := m.Version()
+	if err != nil {
+		if err == migrate.ErrNilVersion {
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+	return !dirty, nil
 }

--- a/database/migration.go
+++ b/database/migration.go
@@ -1,0 +1,27 @@
+package database
+
+import (
+	"github.com/mattes/migrate"
+	_ "github.com/mattes/migrate/database/postgres"
+	_ "github.com/mattes/migrate/source/file"
+)
+
+const MigrationSource string = "file://migrations"
+
+func Migrate(connString string) error {
+	m, err := migrate.New(
+		MigrationSource,
+		connString,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = m.Up()
+	if err != nil {
+		return err
+	}
+
+	_, err = m.Close()
+	return err
+}

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -15,5 +15,5 @@ secrets:
   - signingKey
   - superToken
 
-env:
-    PG_URL: "postgres://sponsorshipportal:LfwA8vQR38Fw@postgres-postgresql/sponsorshipportal-dev?sslmode=disable"
+wants:
+    postgres: PG_URL

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -6,6 +6,9 @@ deployment:
     memory: 1024Mi
     memory_request: 500Mi
 
+health:
+    path: /_health
+
 secrets:
   - AWS_ACCESS_KEY_ID
   - AWS_SECRET_ACCESS_KEY

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -16,4 +16,5 @@ secrets:
   - superToken
 
 wants:
-    postgres: PG_URL
+    postgres:
+        env: PG_URL

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -12,4 +12,5 @@ secrets:
   - signingKey
   - superToken
 
-target_port: 9000
+env:
+    DB_CONNECTIONSTRING: "postgres://sponsorshipportal:LfwA8vQR38Fw@postgres-postgresql/sponsorshipportal-dev?sslmode=disable"

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -16,4 +16,4 @@ secrets:
   - superToken
 
 env:
-    DB_CONNECTIONSTRING: "postgres://sponsorshipportal:LfwA8vQR38Fw@postgres-postgresql/sponsorshipportal-dev?sslmode=disable"
+    PG_URL: "postgres://sponsorshipportal:LfwA8vQR38Fw@postgres-postgresql/sponsorshipportal-dev?sslmode=disable"

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -18,3 +18,13 @@ func New(config *config.Config) *logrus.Logger {
 
 	return log
 }
+
+func SetGlobalLogger(config *config.Config) {
+	if config.Prod {
+		logrus.SetLevel(logrus.InfoLevel)
+		logrus.SetFormatter(&logrus.JSONFormatter{})
+	} else {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetFormatter(&logrus.TextFormatter{})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 
 	"github.com/mattes/migrate"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/HackGT/SponsorshipPortal/config"
 	"github.com/HackGT/SponsorshipPortal/database"
@@ -23,7 +23,7 @@ func dbMigrate() {
 		panic(err)
 	}
 
-	log := logger.New(conf).WithFields(logrus.Fields{
+	log := logger.New(conf).WithFields(log.Fields{
 		"host":   conf.Database.Host,
 		"user":   conf.Database.User,
 		"dbname": conf.Database.DbName,
@@ -52,7 +52,6 @@ func startServer() {
 	if err != nil {
 		panic(err)
 	}
-	log := app.Logger
 
 	// Start the server in a goroutine so it does not block
 	go func() {

--- a/main.go
+++ b/main.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"os"
 	"os/signal"
+
+	"github.com/HackGT/SponsorshipPortal/server"
 )
 
 func main() {
 	// Parts of this is adapted from
 	// https://github.com/gorilla/mux#graceful-shutdown
 
-	app, err := New()
+	app, err := server.New()
 	if err != nil {
 		panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func dbMigrate() {
 
 	log.Info("Migrating database...")
 
-	err = database.Migrate(conf.Database.ConnectionString)
+	err = database.Migrate(conf.Database.URL)
 	if err != nil {
 		if err == migrate.ErrNoChange {
 			log.Warn("No changes detected.")

--- a/migrations/1_init_db.down.sql
+++ b/migrations/1_init_db.down.sql
@@ -1,1 +1,4 @@
-DROP SCHEMA portal CASCADE;
+DROP TABLE sponsors;
+DROP TABLE sponsor_orgs;
+DROP TABLE participants;
+DROP FUNCTION update_timestamp();

--- a/migrations/1_init_db.down.sql
+++ b/migrations/1_init_db.down.sql
@@ -1,0 +1,1 @@
+DROP SCHEMA portal CASCADE;

--- a/migrations/1_init_db.up.sql
+++ b/migrations/1_init_db.up.sql
@@ -1,0 +1,26 @@
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS portal;
+
+SET search_path TO portal, public;
+
+CREATE TABLE IF NOT EXISTS sponsor_org (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sponsor_user (
+    id SERIAL PRIMARY KEY,
+    org_id INTEGER REFERENCES sponsor_org(id),
+    email TEXT NOT NULL,
+    password TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS participant (
+    id SERIAL PRIMARY KEY,
+    registration_id TEXT NOT NULL,
+    document tsvector
+);
+
+CREATE INDEX idx_participant_fts ON participant USING gin(document);
+
+COMMIT;

--- a/migrations/1_init_db.up.sql
+++ b/migrations/1_init_db.up.sql
@@ -1,26 +1,55 @@
 BEGIN;
-CREATE SCHEMA IF NOT EXISTS portal;
 
-SET search_path TO portal, public;
+CREATE OR REPLACE FUNCTION update_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 
-CREATE TABLE IF NOT EXISTS sponsor_org (
-    id SERIAL PRIMARY KEY,
-    name TEXT NOT NULL
+CREATE TABLE IF NOT EXISTS sponsor_orgs (
+    id serial PRIMARY KEY,
+    name text NOT NULL,
+    created_at timestamptz DEFAULT NOW() NOT NULL,
+    updated_at timestamptz DEFAULT NOW() NOT NULL,
+    deleted_at timestamptz
 );
 
-CREATE TABLE IF NOT EXISTS sponsor_user (
-    id SERIAL PRIMARY KEY,
-    org_id INTEGER REFERENCES sponsor_org(id),
-    email TEXT NOT NULL,
-    password TEXT NOT NULL
+CREATE TRIGGER sponsor_orgs_modified_timestamp
+    BEFORE UPDATE ON sponsor_orgs
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_timestamp();
+
+CREATE TABLE IF NOT EXISTS sponsors (
+    id serial PRIMARY KEY,
+    org_id integer REFERENCES sponsor_orgs(id),
+    email text NOT NULL,
+    password text NOT NULL,
+    created_at timestamptz DEFAULT NOW() NOT NULL,
+    updated_at timestamptz DEFAULT NOW() NOT NULL,
+    deleted_at timestamptz
 );
 
-CREATE TABLE IF NOT EXISTS participant (
-    id SERIAL PRIMARY KEY,
-    registration_id TEXT NOT NULL,
-    document tsvector
+CREATE TRIGGER sponsors_modified_timestamp
+    BEFORE UPDATE ON sponsors
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_timestamp();
+
+CREATE TABLE IF NOT EXISTS participants (
+    id serial PRIMARY KEY,
+    registration_id text NOT NULL,
+    document tsvector,
+    created_at timestamptz DEFAULT NOW() NOT NULL,
+    updated_at timestamptz DEFAULT NOW() NOT NULL,
+    deleted_at timestamptz
 );
 
-CREATE INDEX idx_participant_fts ON participant USING gin(document);
+CREATE TRIGGER participants_modified_timestamp
+    BEFORE UPDATE ON participants
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_timestamp();
+
+CREATE INDEX participant_full_text_index ON participants USING gin(document);
 
 COMMIT;

--- a/migrations/1_init_db.up.sql
+++ b/migrations/1_init_db.up.sql
@@ -24,7 +24,7 @@ CREATE TRIGGER sponsor_orgs_modified_timestamp
 CREATE TABLE IF NOT EXISTS sponsors (
     id serial PRIMARY KEY,
     org_id integer REFERENCES sponsor_orgs(id),
-    email text NOT NULL,
+    email text UNIQUE NOT NULL,
     password text NOT NULL,
     created_at timestamptz DEFAULT NOW() NOT NULL,
     updated_at timestamptz DEFAULT NOW() NOT NULL,
@@ -38,7 +38,7 @@ CREATE TRIGGER sponsors_modified_timestamp
 
 CREATE TABLE IF NOT EXISTS participants (
     id serial PRIMARY KEY,
-    registration_id text NOT NULL,
+    registration_id text UNIQUE NOT NULL,
     document tsvector,
     created_at timestamptz DEFAULT NOW() NOT NULL,
     updated_at timestamptz DEFAULT NOW() NOT NULL,

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,4 +1,4 @@
-# MIgrations
+# Migrations
 
 All migrations should be written with a `up` and `down` scripts that will
 apply and remove the schema changes respectively.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,17 @@
+# MIgrations
+
+All migrations should be written with a `up` and `down` scripts that will
+apply and remove the schema changes respectively.
+
+From [`mattes/migrate`](https://github.com/mattes/migrate)
+[best practices](https://github.com/mattes/migrate/blob/master/MIGRATIONS.md)
+docs:
+> The ordering and direction of the migration files is determined by the filenames used for them. migrate expects the filenames of migrations to have the format:
+>
+> {version}_{title}.up.{extension}
+> {version}_{title}.down.{extension}
+>
+> The title of each migration is unused, and is only for readability. Similarly, the extension of the migration files is not checked by the library, and should be an appropriate format for the database in use (.sql for SQL variants, for instance).
+
+Please read the [best practices](https://github.com/mattes/migrate/blob/master/MIGRATIONS.md)
+for more information and details.

--- a/model/model.go
+++ b/model/model.go
@@ -1,0 +1,11 @@
+package model
+
+import (
+	"database/sql"
+)
+
+type Connection interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+	Get(dest interface{}, query string, args ...interface{}) error
+	Select(dest interface{}, query string, args ...interface{}) error
+}

--- a/model/org/org.go
+++ b/model/org/org.go
@@ -1,0 +1,51 @@
+package org
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/HackGT/SponsorshipPortal/model"
+)
+
+const (
+	table = "sponsor_orgs"
+)
+
+type Org struct {
+	ID   int64  `db:"id"`
+	Name string `db:"name"`
+}
+
+func ByID(db model.Connection, id int64) (Org, bool, error) {
+	result := Org{}
+	err := db.Get(&result, fmt.Sprintf(`
+SELECT id, name
+FROM %v
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1`,
+		table), id)
+	return result, err != sql.ErrNoRows, err
+}
+
+func ByName(db model.Connection, name string) (Org, bool, error) {
+	result := Org{}
+	err := db.Get(&result, fmt.Sprintf(`
+SELECT id, name
+FROM %v
+WHERE name = $1
+  AND deleted_at IS NULL
+LIMIT 1`,
+		table), name)
+	return result, err != sql.ErrNoRows, err
+}
+
+func Create(db model.Connection, name string) (sql.Result, error) {
+	result, err := db.Exec(fmt.Sprintf(`
+INSERT INTO %v
+(name)
+VALUES
+($1)`,
+		table), name)
+	return result, err
+}

--- a/model/org/org_test.go
+++ b/model/org/org_test.go
@@ -1,0 +1,94 @@
+package org
+
+import (
+	"database/sql"
+	"testing"
+
+	modeltesting "github.com/HackGT/SponsorshipPortal/model/testing"
+)
+
+func TestByID(t *testing.T) {
+	getReqChan := make(chan *modeltesting.QueryRequest, 1)
+	getRespChan := make(chan error, 1)
+	db := &modeltesting.MockConnection{
+		GetReq:  getReqChan,
+		GetResp: getRespChan,
+	}
+
+	// success case
+	var id int64 = 1
+	getRespChan <- nil
+	_, found, err := ByID(db, id)
+	if err != nil || found != true {
+		t.Errorf("Expected no error and found=true, instead got: found=%v, err=%v", found, err)
+	}
+	query := <-getReqChan
+	if len(query.Args) != 1 || query.Args[0] != id {
+		t.Errorf("Expected query args to contain only id=%v, instead got: args=%v", id, query.Args)
+	}
+
+	// error - no rows
+	id = int64(2)
+	getRespChan <- sql.ErrNoRows
+	_, found, err = ByID(db, id)
+	if err != sql.ErrNoRows || found != false {
+		t.Errorf("Expected error=sql.ErrNoRows and found=false, instead got: found=%v, err=%v", found, err)
+	}
+	query = <-getReqChan
+	if len(query.Args) != 1 || query.Args[0] != id {
+		t.Errorf("Expected query args to contain only id=%v, instead got: args=%v", id, query.Args)
+	}
+}
+
+func TestByName(t *testing.T) {
+	getReqChan := make(chan *modeltesting.QueryRequest, 1)
+	getRespChan := make(chan error, 1)
+	db := &modeltesting.MockConnection{
+		GetReq:  getReqChan,
+		GetResp: getRespChan,
+	}
+
+	// success case
+	name := "name1"
+	getRespChan <- nil
+	_, found, err := ByName(db, name)
+	if err != nil || found != true {
+		t.Errorf("Expected no error and found=true, instead got: found=%v, err=%v", found, err)
+	}
+	query := <-getReqChan
+	if len(query.Args) != 1 || query.Args[0] != name {
+		t.Errorf("Expected query args to contain only name=%v, instead got: args=%v", name, query.Args)
+	}
+
+	// error - no rows
+	name = "name2"
+	getRespChan <- sql.ErrNoRows
+	_, found, err = ByName(db, name)
+	if err != sql.ErrNoRows || found != false {
+		t.Errorf("Expected error=sql.ErrNoRows and found=false, instead got: found=%v, err=%v", found, err)
+	}
+	query = <-getReqChan
+	if len(query.Args) != 1 || query.Args[0] != name {
+		t.Errorf("Expected query args to contain only name=%v, instead got: args=%v", name, query.Args)
+	}
+}
+
+func TestCreate(t *testing.T) {
+	execReqChan := make(chan *modeltesting.QueryRequest, 1)
+	execRespChan := make(chan *modeltesting.SQLResultErrorPair, 1)
+	db := &modeltesting.MockConnection{
+		ExecReq:  execReqChan,
+		ExecResp: execRespChan,
+	}
+
+	execRespChan <- &modeltesting.SQLResultErrorPair{}
+	name := "org_name"
+	_, err := Create(db, name)
+	if err != nil {
+		t.Errorf("Expected nil-error, instead got: error=%v", err)
+	}
+	query := <-execReqChan
+	if len(query.Args) != 1 || query.Args[0] != name {
+		t.Errorf("Expected query args to contain only name=%v, instead got: args=%v", name, query.Args)
+	}
+}

--- a/model/participant/participant.go
+++ b/model/participant/participant.go
@@ -1,0 +1,64 @@
+package participant
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/HackGT/SponsorshipPortal/model"
+)
+
+const (
+	table = "participants"
+)
+
+var (
+	ErrNotImplemented = errors.New("not implemented")
+)
+
+type Participant struct {
+	ID             int64  `db:"id"`
+	RegistrationID string `db:"registration_id"`
+}
+
+func ByID(db model.Connection, id int64) (Participant, bool, error) {
+	result := Participant{}
+	err := db.Get(&result, fmt.Sprintf(`
+SELECT id, registration_id
+FROM %v
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1`,
+		table), id)
+	return result, err != sql.ErrNoRows, err
+}
+
+func ByRegistrationID(db model.Connection, regID string) (Participant, bool, error) {
+	result := Participant{}
+	err := db.Get(&result, fmt.Sprintf(`
+SELECT id, registration_id
+FROM %v
+WHERE registration_id = $1
+  AND deleted_at IS NULL
+LIMIT 1`,
+		table), regID)
+	return result, err != sql.ErrNoRows, err
+}
+
+func MatchKeywords(db model.Connection, keywords ...string) ([]Participant, error) {
+	return nil, ErrNotImplemented
+}
+
+func Create(db model.Connection, regID string) (sql.Result, error) {
+	result, err := db.Exec(fmt.Sprintf(`
+INSERT INTO %v
+(registration_id)
+VALUES
+($1)`,
+		table), regID)
+	return result, err
+}
+
+func (p *Participant) SetDocumentContents(db model.Connection, doc string) (sql.Result, error) {
+	return nil, ErrNotImplemented
+}

--- a/model/participant/participant_test.go
+++ b/model/participant/participant_test.go
@@ -1,0 +1,74 @@
+package participant
+
+import (
+	"database/sql"
+	"testing"
+
+	modeltesting "github.com/HackGT/SponsorshipPortal/model/testing"
+)
+
+func TestByID(t *testing.T) {
+	getReqChan := make(chan *modeltesting.QueryRequest, 1)
+	getRespChan := make(chan error, 1)
+	db := &modeltesting.MockConnection{
+		GetReq:  getReqChan,
+		GetResp: getRespChan,
+	}
+
+	// success case
+	var id int64 = 1
+	getRespChan <- nil
+	_, found, err := ByID(db, id)
+	if err != nil || found != true {
+		t.Errorf("Expected no error and found=true, instead got: found=%v, err=%v", found, err)
+	}
+	query := <-getReqChan
+	if len(query.Args) != 1 || query.Args[0] != id {
+		t.Errorf("Expected query args to contain only id=%v, instead got: args=%v", id, query.Args)
+	}
+
+	// error - no rows
+	id = int64(2)
+	getRespChan <- sql.ErrNoRows
+	_, found, err = ByID(db, id)
+	if err != sql.ErrNoRows || found != false {
+		t.Errorf("Expected error=sql.ErrNoRows and found=false, instead got: found=%v, err=%v", found, err)
+	}
+	query = <-getReqChan
+	if len(query.Args) != 1 || query.Args[0] != id {
+		t.Errorf("Expected query args to contain only id=%v, instead got: args=%v", id, query.Args)
+	}
+}
+
+func TestByRegistrationID(t *testing.T) {
+	getReqChan := make(chan *modeltesting.QueryRequest, 1)
+	getRespChan := make(chan error, 1)
+	db := &modeltesting.MockConnection{
+		GetReq:  getReqChan,
+		GetResp: getRespChan,
+	}
+
+	// success case
+	regID := "id1"
+	getRespChan <- nil
+	_, found, err := ByRegistrationID(db, regID)
+	if err != nil || found != true {
+		t.Errorf("Expected no error and found=true, instead got: found=%v, err=%v", found, err)
+	}
+	query := <-getReqChan
+	if len(query.Args) != 1 || query.Args[0] != regID {
+		t.Errorf("Expected query args to contain only regID=%v, instead got: args=%v", regID, query.Args)
+	}
+
+	// error - no rows
+	regID = "id2"
+	getRespChan <- sql.ErrNoRows
+	_, found, err = ByRegistrationID(db, regID)
+	if err != sql.ErrNoRows || found != false {
+		t.Errorf("Expected error=sql.ErrNoRows and found=false, instead got: found=%v, err=%v", found, err)
+	}
+	query = <-getReqChan
+	if len(query.Args) != 1 || query.Args[0] != regID {
+		t.Errorf("Expected query args to contain only regID=%v, instead got: args=%v", regID, query.Args)
+	}
+}

--- a/model/testing/mock.go
+++ b/model/testing/mock.go
@@ -1,0 +1,71 @@
+package testing
+
+import (
+	"database/sql"
+	"errors"
+
+	"github.com/HackGT/SponsorshipPortal/model"
+)
+
+var (
+	ErrNotImplemented = errors.New("not implemented")
+	ErrMockClosed     = errors.New("mock connection closed")
+)
+
+type QueryRequest struct {
+	Dest  interface{}
+	Query string
+	Args  []interface{}
+}
+
+type SQLResultErrorPair struct {
+	Result sql.Result
+	Error  error
+}
+
+type MockConnection struct {
+	ExecReq    chan *QueryRequest
+	ExecResp   chan *SQLResultErrorPair
+	GetReq     chan *QueryRequest
+	GetResp    chan error
+	SelectReq  chan *QueryRequest
+	SelectResp chan error
+}
+
+var _ model.Connection = &MockConnection{}
+
+func (m *MockConnection) Exec(query string, args ...interface{}) (sql.Result, error) {
+	if m.ExecReq == nil || m.ExecResp == nil {
+		return nil, ErrNotImplemented
+	}
+	m.ExecReq <- &QueryRequest{Query: query, Args: args}
+	result, ok := <-m.ExecResp
+	if !ok {
+		return nil, ErrMockClosed
+	}
+	return result.Result, result.Error
+}
+
+func (m *MockConnection) Get(dest interface{}, query string, args ...interface{}) error {
+	if m.GetReq == nil || m.GetResp == nil {
+		return ErrNotImplemented
+	}
+	m.GetReq <- &QueryRequest{dest, query, args}
+	result, ok := <-m.GetResp
+	if !ok {
+		return ErrMockClosed
+	}
+	return result
+}
+
+func (m *MockConnection) Select(dest interface{}, query string, args ...interface{}) error {
+	if m.SelectReq == nil || m.SelectResp == nil {
+		return ErrNotImplemented
+	}
+	m.SelectReq <- &QueryRequest{dest, query, args}
+	result, ok := <-m.SelectResp
+	if !ok {
+		return ErrMockClosed
+	}
+	return result
+}

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -1,0 +1,53 @@
+package user
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/HackGT/SponsorshipPortal/model"
+)
+
+const (
+	table = "sponsors"
+)
+
+type User struct {
+	ID       int64  `db:"id"`
+	OrgID    int64  `db:"org_id"`
+	Email    string `db:"email"`
+	Password string `db:"password"`
+}
+
+func ByEmail(db model.Connection, email string) (User, bool, error) {
+	result := User{}
+	err := db.Get(&result, fmt.Sprintf(`
+SELECT id, org_id, email, password
+FROM %v
+WHERE email = $1
+  AND deleted_at IS NULL
+LIMIT 1`,
+		table), email)
+	return result, err != sql.ErrNoRows, err
+}
+
+func Create(db model.Connection, orgID int64, email, password string) (sql.Result, error) {
+	result, err := db.Exec(fmt.Sprintf(`
+INSERT INTO %v
+(org_id, email, password)
+VALUES
+($1, $2, $3)`,
+		table), orgID, email, password)
+	return result, err
+}
+
+func (u *User) Save(db model.Connection) (sql.Result, error) {
+	result, err := db.Exec(fmt.Sprintf(`
+UPDATE %v
+   SET org_id = $1,
+       email = $2,
+       password = $3
+ WHERE id = $4;
+`,
+		table), u.OrgID, u.Email, u.Password, u.ID)
+	return result, err
+}

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -1,0 +1,91 @@
+package user
+
+import (
+	"database/sql"
+	"testing"
+
+	modeltesting "github.com/HackGT/SponsorshipPortal/model/testing"
+)
+
+func TestByEmail(t *testing.T) {
+	getReqChan := make(chan *modeltesting.QueryRequest, 1)
+	getRespChan := make(chan error, 1)
+	db := &modeltesting.MockConnection{
+		GetReq:  getReqChan,
+		GetResp: getRespChan,
+	}
+
+	// success case
+	email := "testworkingemail@hack.gt"
+	getRespChan <- nil
+	_, found, err := ByEmail(db, email)
+	if err != nil || found != true {
+		t.Errorf("Expected no error and found=true, instead got: found=%v, err=%v", found, err)
+	}
+	query := <-getReqChan
+	if len(query.Args) != 1 || query.Args[0] != email {
+		t.Errorf("Expected query args to contain only email=%v, instead got: args=%v", email, query.Args)
+	}
+
+	// error - no rows
+	email = "testfailingemail@hack.gt"
+	getRespChan <- sql.ErrNoRows
+	_, found, err = ByEmail(db, email)
+	if err != sql.ErrNoRows || found != false {
+		t.Errorf("Expected error=sql.ErrNoRows and found=false, instead got: found=%v, err=%v", found, err)
+	}
+	query = <-getReqChan
+	if len(query.Args) != 1 || query.Args[0] != email {
+		t.Errorf("Expected query args to contain only email=%v, instead got: args=%v", email, query.Args)
+	}
+}
+
+func TestCreate(t *testing.T) {
+	execReqChan := make(chan *modeltesting.QueryRequest, 1)
+	execRespChan := make(chan *modeltesting.SQLResultErrorPair, 1)
+	db := &modeltesting.MockConnection{
+		ExecReq:  execReqChan,
+		ExecResp: execRespChan,
+	}
+
+	execRespChan <- &modeltesting.SQLResultErrorPair{}
+	orgID := int64(0)
+	email := "test@hack.gt"
+	password := "bloop"
+	_, err := Create(db, orgID, email, password)
+	if err != nil {
+		t.Errorf("Expected nil-error, instead got: error=%v", err)
+	}
+	query := <-execReqChan
+	if len(query.Args) != 3 || query.Args[0] != orgID || query.Args[1] != email || query.Args[2] != password {
+		t.Errorf("Expected query args to contain [%v, %v, %v], instead got: args=%v", orgID, email, password, query.Args)
+	}
+}
+
+func TestSave(t *testing.T) {
+	execReqChan := make(chan *modeltesting.QueryRequest, 1)
+	execRespChan := make(chan *modeltesting.SQLResultErrorPair, 1)
+	db := &modeltesting.MockConnection{
+		ExecReq:  execReqChan,
+		ExecResp: execRespChan,
+	}
+
+	execRespChan <- &modeltesting.SQLResultErrorPair{}
+
+	testUser := &User{
+		ID:       int64(0),
+		OrgID:    int64(1),
+		Email:    "test@hack.gt",
+		Password: "bloop",
+	}
+
+	_, err := testUser.Save(db)
+	if err != nil {
+		t.Errorf("Expected nil-error, instead got: error=%v", err)
+	}
+	query := <-execReqChan
+	if len(query.Args) != 4 || query.Args[0] != testUser.OrgID || query.Args[1] != testUser.Email || query.Args[2] != testUser.Password || query.Args[3] != testUser.ID {
+		t.Errorf("Expected query args to contain [%v, %v, %v, %v], instead got: args=%v", testUser.OrgID, testUser.Email, testUser.Password, testUser.ID, query.Args)
+	}
+
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -1,4 +1,4 @@
-package main
+package server
 
 import (
 	"net/http"

--- a/server/routes.go
+++ b/server/routes.go
@@ -5,23 +5,25 @@ import (
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
-	"github.com/sirupsen/logrus"
 
-	"github.com/HackGT/SponsorshipPortal/controller"
+	ctrl "github.com/HackGT/SponsorshipPortal/controller"
+	"github.com/HackGT/SponsorshipPortal/logger"
 )
 
-func NewRouter(logger *logrus.Logger) http.Handler {
+func (app *App) NewRouter() http.Handler {
 	r := mux.NewRouter()
 
 	// Load controllers
+	controller := ctrl.New(app.DB, app.Config)
 	controller.Load(r)
 
 	// Add handler for static files
 	r.Methods("GET").Handler(http.FileServer(http.Dir("./client/static/")))
 
 	// Attach logging and recovery middlewares
+	log := logger.New(app.Config)
 	var handler http.Handler
-	handler = handlers.LoggingHandler(logger.Writer(), r)
-	handler = handlers.RecoveryHandler(handlers.RecoveryLogger(logger))(handler)
+	handler = handlers.LoggingHandler(log.Writer(), r)
+	handler = handlers.RecoveryHandler(handlers.RecoveryLogger(log))(handler)
 	return handler
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1,4 +1,4 @@
-package main
+package server
 
 import (
 	"net/http"


### PR DESCRIPTION
- [x] Update README with new PostgreSQL dependency and config steps
- [x] Add support for database migrations (run as cli flag on server binary)
- [x] Initialize database (with first migration) to set up schema and tables
- [x] Update README with instructions on how to run database migrations
- [x] Update README with instructions on how to create database migrations
- [x] Add models for created tables
- [x] Add tests for models
- [Future TODO] Automatically create an admin user from environment variables if none is present

We can now run database migrations using the `--migrate` flag! Example: `go run main.go --migrate` or `go build . && ./SponsorshipPortal --migrate` (You have to have the correct database config/connection strings as environment variables).

Open questions:
- [x] How does this get integrated/automated with Docker/k8s/deployment? cc @illegalprime @ehsanmasdar 
  - [x] **Migrations:** Application containers will check for and apply any pending migrations before boot up at each deploy. Applications will also report unhealthy on `/_health` endpoint while database is in a dirty (incomplete) migration state. (bbd2a0c)
  - [x] **Database creation:** ??? Ideally we can create a new database (`CREATE DATABASE`) for each PR automatically so we can isolate issues.
✅ Ideally HackGT/biodomes#16 is implemented and takes care of this.
  - [Future TODO] **Seeding:** ??? It would be nice to have a dev script that automatically populated the database (both on local dev environments and any deployed non-production instances) with some test data.


Continues/will finish move to PostgreSQL (#44)