### PR TITLE
Improve frontend config to automatically change API host by env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ For development work run the frontend and backend separately.
 
 ### Install dependencies
 
-Before running the frontend for development change the file `frontend/src/js/configs.js` to assign the HOST to `export const HOST = window.location.protocol + '//' + 'localhost:9000';` This needs to be done or server-side communication won't work. (TODO: host should change automatically from environment variable)
-
 Install frontend dependencies:
 ```bash
 # from project root

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -7,6 +7,7 @@
     "new-cap": 0,
     "no-implied-eval": 2,
     "react/no-danger": 2,
+    "linebreak-style": 0,
     "no-undef": 0,
     "no-class-assign": 0,
     "no-else-return": 0,

--- a/client/src/js/configs.js
+++ b/client/src/js/configs.js
@@ -1,2 +1,20 @@
-export const HOST = window.location.protocol + '//' + window.location.host;
-export const TITLE = 'HackGT Sponsorship Portal'; // TODO: This is not in use yet
+/**
+ * -------------------
+ * User Customizations
+ * -------------------
+ */
+
+// Title shown in various parts of the UI
+export const TITLE = 'HackGT Sponsorship Portal';
+
+
+/**
+ * --------------------
+ * API Configurations
+ * --------------------
+ */
+
+// Use this to determine whether it is dev environment
+export const IS_DEV_ENV = process.env.DEVELOPMENT;
+// API URL
+export const HOST = (!IS_DEV_ENV) ? (window.location.protocol + '//' + window.location.host) : 'http://localhost:9000';


### PR DESCRIPTION
A tiny fix that removes the need of manually setting dev env API to localhost.